### PR TITLE
Permission fixes on daemon, install script clarifications, and instant create-val 

### DIFF
--- a/AutoNode/daemon.py
+++ b/AutoNode/daemon.py
@@ -94,6 +94,9 @@ class Daemon:
                 # Invariant: Monitor will raise a ResetNode exception to trigger a node reset,
                 # otherwise it will gracefully exit to restart monitor
                 start_monitor()
+                if not node_config['auto-reset']:
+                    log(f"{Typgpy.WARNING}Terminating monitor...{Typgpy.ENDC}")
+                    return
             except ResetNode as e:  # All other errors should blow up
                 log(f"{Typgpy.FAIL}Resetting Node: {e}{Typgpy.ENDC}")
                 if not node_config['auto-reset']:
@@ -104,7 +107,6 @@ class Daemon:
                 daemon_name = f"{self.name}@node_recovered.service"
                 log(f"{Typgpy.WARNING}Starting daemon {daemon_name}{Typgpy.ENDC}")
                 subprocess.check_call(f"sudo systemctl start {daemon_name}", shell=True, env=os.environ)
-            log(f"{Typgpy.WARNING}Terminating monitor...{Typgpy.ENDC}")
 
     def start(self):
         if self.service == 'monitor':

--- a/AutoNode/daemon.py
+++ b/AutoNode/daemon.py
@@ -26,7 +26,7 @@ from .monitor import (
     start as start_monitor,
     ResetNode
 )
-from.util import (
+from .util import (
     get_simple_rotating_log_handler
 )
 

--- a/AutoNode/monitor.py
+++ b/AutoNode/monitor.py
@@ -88,6 +88,7 @@ def _wait_for_node_block_two():
         wait_for_node_response("http://localhost:9500/", verbose=True, sleep=1, tries=300)  # Try for 5 min
         log(f"{Typgpy.HEADER}Waiting for block 2 on node...{Typgpy.ENDC}")
     except (ConnectionError, TimeoutError) as e:
+        log(f"{Typgpy.FAIL}Could not connect to node after 5 min...{Typgpy.ENDC}")
         raise ResetNode(clean=True) from e
     count = 0
     try:

--- a/AutoNode/monitor.py
+++ b/AutoNode/monitor.py
@@ -119,6 +119,9 @@ def _run_monitor(shard_endpoint):
     count = 0
     while curr_time - start_time < duration:
         if node_config["auto-reset"]:
+            if subprocess.call("sudo -n true", shell=True, env=os.environ) != 0:
+                log(f"{Typgpy.WARNING}Cannot trigger auto-reset if there is a Hard reset. \n"
+                    f"User {os.environ['USER']} does not have sudo access without passphrase.{Typgpy.ENDC}")
             _check_for_hard_reset(shard_endpoint)
         log(f"{Typgpy.HEADER}Validator address: {Typgpy.OKGREEN}{validator_config['validator-addr']}{Typgpy.ENDC}")
         meta_data = get_metadata('http://localhost:9500/')
@@ -165,6 +168,10 @@ def start():
     old_logging_handlers = logging.getLogger('AutoNode').handlers.copy()
     logging.getLogger('AutoNode').addHandler(get_simple_rotating_log_handler(log_path))
     log(f"{Typgpy.HEADER}Starting monitor...{Typgpy.ENDC}")
+    if node_config['auto-reset'] and subprocess.call("sudo -n true", shell=True, env=os.environ) != 0:
+        log(f"{Typgpy.WARNING}User {os.environ['USER']} does not have sudo privileges without password.\n "
+            f"For auto-reset option, user must have said privilege. Continuing...{Typgpy.ENDC}")
+        time.sleep(2)  # So user can read message...
     try:
         shard_endpoint = _init()
         _run_monitor(shard_endpoint)

--- a/AutoNode/monitor.py
+++ b/AutoNode/monitor.py
@@ -121,8 +121,8 @@ def _run_monitor(shard_endpoint):
     while curr_time - start_time < duration:
         if node_config["auto-reset"]:
             if subprocess.call("sudo -n true", shell=True, env=os.environ) != 0:
-                log(f"{Typgpy.WARNING}Cannot trigger auto-reset if there is a Hard reset. \n"
-                    f"User {os.environ['USER']} does not have sudo access without passphrase.{Typgpy.ENDC}")
+                log(f"{Typgpy.WARNING}User {os.environ['USER']} does not have sudo access without passphrase.\n " 
+                    f"Cannot trigger auto-reset if there is a Hard reset.{Typgpy.ENDC}")
             _check_for_hard_reset(shard_endpoint)
         log(f"{Typgpy.HEADER}Validator address: {Typgpy.OKGREEN}{validator_config['validator-addr']}{Typgpy.ENDC}")
         meta_data = get_metadata('http://localhost:9500/')

--- a/AutoNode/node.py
+++ b/AutoNode/node.py
@@ -9,17 +9,14 @@ import logging
 import requests
 
 from pyhmy import (
-    cli,
     Typgpy
 )
 
 from .common import (
     log,
-    validator_config,
     node_script_source,
     node_sh_log_dir,
     node_config,
-    saved_wallet_pass_path,
     node_dir,
     bls_key_dir,
     sync_dir_map,
@@ -32,6 +29,9 @@ from .blockchain import (
 from .util import (
     input_with_print,
     get_simple_rotating_log_handler
+)
+from .validator import (
+    activate_validator
 )
 
 node_sh_out_path = f"{node_sh_log_dir}/out.log"
@@ -176,11 +176,7 @@ def check_and_activate(epos_status_msg):
         wait_for_node_response(node_config['endpoint'], tries=900, sleep=1, verbose=False)  # Try for 15 min
         ref_epoch = get_latest_header(node_config['endpoint'])['epoch']
         if curr_epoch_shard == ref_epoch and curr_epoch_beacon == ref_epoch:
-            response = cli.single_call(
-                f"hmy staking edit-validator --validator-addr {validator_config['validator-addr']} "
-                f"--active true --node {node_config['endpoint']} "
-                f"--passphrase-file {saved_wallet_pass_path} ")
-            log(f"{Typgpy.OKGREEN}Edit-validator response: {response}{Typgpy.ENDC}")
+            activate_validator()
             return True
         else:
             log(f"{Typgpy.WARNING}Node not synced, did NOT activate node.{Typgpy.ENDC}")

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ Documentation for most users can be found [here](https://docs.harmony.one/home/v
 
 **1) Install AutoNode with the following command:**
 ```bash
-bash <(curl -s -S -L 'https://raw.githubusercontent.com/harmony-one/auto-node/master/scripts/install.sh')
-```
-
-or
-
-```bash
 curl -O https://raw.githubusercontent.com/harmony-one/auto-node/master/scripts/install.sh && chmod +x ./install.sh && ./install.sh && rm ./install.sh
 ```
 

--- a/scripts/auto_node.sh
+++ b/scripts/auto_node.sh
@@ -3,9 +3,17 @@
 set -e
 
 # TODO: convert auto_node.sh into python3 click CLI since lib is in python3.
+function yes_or_exit(){
+  read -r reply
+  if [[ ! $reply =~ ^[Yy]$ ]]
+  then
+    exit 1
+  fi
+}
+
 if (( "$EUID" == 0 )); then
-  echo "Do not run as root"
-  exit
+  echo "You are running as root, which is not recommended. Continue (y/n)?"
+  yes_or_exit
 fi
 
 case "${1}" in

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -50,9 +50,11 @@ def assert_dead_daemons():
 if __name__ == "__main__":
     args = parse_args()
     assert_dead_daemons()
+    if args.auto_reset and subprocess.call("sudo -n true", shell=True, env=os.environ) != 0:
+        raise SystemExit(
+            f"{Typgpy.FAIL}User {os.environ['USER']} does not have sudo privileges without password.\n "
+            f"For `--auto-reset` option, user must have said privilege.{Typgpy.ENDC}")
     AutoNode.initialize.reset()
-    if args.auto_reset:
-        Daemon.assert_perms_for_auto_reset()
     AutoNode.node_config.update({
         "endpoint": args.endpoint,
         "network": args.network,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ if ! command -v systemctl > /dev/null; then
 fi
 
 
-stable_auto_node_version="0.1.9"
+stable_auto_node_version="0.2.0"
 
 function check_and_install(){
   pkg=$1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-echo "[AutoNode] Starting installation for user $USER (with home: $HOME)"
-
-sleep 5
-
-# Do prechecks for absolute requirements..
 if [ "$(uname)" != "Linux" ]; then
   echo "[AutoNode] not on a Linux machine, exiting."
-  exit
-fi
-if (( "$EUID" == 0 )); then
-  echo "Do not install as root"
   exit
 fi
 if ! command -v systemctl > /dev/null; then
   echo "[AutoNode] distro does not have systemd, exiting."
   exit
 fi
+
+
+stable_auto_node_version="0.1.8"
 
 function check_and_install(){
   pkg=$1
@@ -40,6 +34,22 @@ function yes_or_exit(){
   fi
 }
 
+echo "[AutoNode] Starting installation for user $USER (with home: $HOME)"
+echo "[AutoNode] Will install the following:"
+echo "           * AutoNode ($stable_auto_node_version) python3 library and all dependencies"
+echo "           * autonode_service.py service script in $HOME/bin"
+echo "           * auto_node.sh main shell script in $HOME"
+echo "           * validator_config.json config file in $HOME"
+echo "           * harmony node files generated in $HOME/harmony_node"
+echo "           * supporting script, saved configs, and BLS key(s) will generated/saved in $HOME/.hmy"
+echo "[AutoNode] Continue to install (y/n)?"
+yes_or_exit
+
+if (( "$EUID" == 0 )); then
+  echo "You are installing as root, which is not recommended. Continue (y/n)?"
+  yes_or_exit
+fi
+
 echo "[AutoNode] Installing for user $USER"
 echo "[AutoNode] Checking dependencies..."
 unset PKG_INSTALL
@@ -57,7 +67,7 @@ done
 echo "[AutoNode] Removing existing AutoNode installation"
 pip3 uninstall AutoNode -y 2>/dev/null || sudo pip3 uninstall AutoNode -y 2>/dev/null || echo "[AutoNode] Was not installed..."
 echo "[AutoNode] Installing main python3 library"
-pip3 install AutoNode==0.1.6 --no-cache-dir --user || sudo pip3 install AutoNode==0.1.6 --no-cache-dir
+pip3 install AutoNode=="$stable_auto_node_version"--no-cache-dir --user || sudo pip3 install AutoNode=="$stable_auto_node_version" --no-cache-dir
 echo "[AutoNode] Initilizing python3 library"
 python3 -c "from AutoNode import common; common.save_validator_config()" > /dev/null
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ if ! command -v systemctl > /dev/null; then
 fi
 
 
-stable_auto_node_version="0.1.8"
+stable_auto_node_version="0.1.9"
 
 function check_and_install(){
   pkg=$1
@@ -67,7 +67,7 @@ done
 echo "[AutoNode] Removing existing AutoNode installation"
 pip3 uninstall AutoNode -y 2>/dev/null || sudo pip3 uninstall AutoNode -y 2>/dev/null || echo "[AutoNode] Was not installed..."
 echo "[AutoNode] Installing main python3 library"
-pip3 install AutoNode=="$stable_auto_node_version"--no-cache-dir --user || sudo pip3 install AutoNode=="$stable_auto_node_version" --no-cache-dir
+pip3 install AutoNode=="$stable_auto_node_version" --no-cache-dir --user || sudo pip3 install AutoNode=="$stable_auto_node_version" --no-cache-dir
 echo "[AutoNode] Initilizing python3 library"
 python3 -c "from AutoNode import common; common.save_validator_config()" > /dev/null
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='AutoNode',
-    version=f"0.1.8",
+    version=f"0.1.9",
     description="AutoNode Python Library",
     author='Daniel Van Der Maden',
     author_email='daniel@harmony.one',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='AutoNode',
-    version=f"0.1.6",
+    version=f"0.1.8",
     description="AutoNode Python Library",
     author='Daniel Van Der Maden',
     author_email='daniel@harmony.one',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='AutoNode',
-    version=f"0.1.9",
+    version=f"0.2.0",
     description="AutoNode Python Library",
     author='Daniel Van Der Maden',
     author_email='daniel@harmony.one',


### PR DESCRIPTION
Fixed the permission error that was brought up by P-OPS.
Added installation clarifications as well as allow sudo to install with a warning.  
Will now create a validator instantly and deactivate until node synced, then will activate. 